### PR TITLE
call database.session.rollback() on transaction fail

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -72,6 +72,7 @@ def cmd_adduser(nick, args, admin):
             try:
                 database.session.commit()
             except sqlalchemy.exc.IntegrityError:
+                database.session.rollback()
                 return 'Már létezik felhasználó ilyen névvel.'
             else:
                 return args.split()[0] + ' hozzáadva!'
@@ -94,6 +95,7 @@ def cmd_addpattern(nick, args, admin):
                 try:
                     database.session.commit()
                 except sqlalchemy.exc.IntegrityError:
+                    database.session.rollback()
                     return 'Ez a pattern már hozzá van rendelve ehhez a felhasználóhoz.'
                 else:
                     return ' '.join(args.split()[1:]) + ' hozzáadva!'
@@ -127,6 +129,7 @@ def cmd_addwelcome(nick, args, admin):
                 try:
                     database.session.commit()
                 except sqlalchemy.exc.IntegrityError:
+                    database.session.rollback()
                     return 'Ez a köszöntés már hozzá van rendelve ehhez a felhasználóhoz.'
                 else:
                     return ' '.join(args.split()[1:]) + ' hozzáadva!'


### PR DESCRIPTION
fix for "This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (sqlite3.IntegrityError) UNIQUE constraint failed: users.name [SQL: 'INSERT INTO users (name, is_admin) VALUES (?, ?)'] [parameters: ('janos', None)] (Background on this error at: http://sqlalche.me/e/gkpj)"